### PR TITLE
Added new user's script for V2 user using the Bitdefender mount

### DIFF
--- a/package/base-files/files/etc/rc.local
+++ b/package/base-files/files/etc/rc.local
@@ -6,4 +6,7 @@
 # Run own user's script if exists (NG partition)
 [ -f /mnt/ntgr/rc.user ] && /bin/sh /mnt/ntgr/rc.user
 
+# Run own user's script for v2 user if exists (Bitdefender partition)
+[ -f /mnt/bitdefender/rc.user ] && /bin/sh /mnt/bitdefender/rc.user
+
 exit 0

--- a/package/base-files/files_dni/etc/rc.local
+++ b/package/base-files/files_dni/etc/rc.local
@@ -6,4 +6,7 @@
 # Run own user's script if exists (NG partition)
 [ -f /mnt/ntgr/rc.user ] && /bin/sh /mnt/ntgr/rc.user
 
+# Run own user's script for v2 user if exists (Bitdefender partition)
+[ -f /mnt/bitdefender/rc.user ] && /bin/sh /mnt/bitdefender/rc.user
+
 exit 0


### PR DESCRIPTION
This adds a new user script path to rc.local.
As I have V2 box I'm unable to make persistent changes to the ntgr folder so each time the router resets entware is lost.

Entware can (just) about fit on the Bidfender partition so this seems like the best place to use.

I'm unable to compile this to test it but shouldn't break anything.